### PR TITLE
radit flexing

### DIFF
--- a/coba_test.go
+++ b/coba_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkGacha(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		SimulateLootRNG()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"regexp"
 	"runtime"
+	"sync"
 	"time"
 )
 
@@ -22,6 +23,7 @@ func SimulateLootRNG() {
 	rand.Seed(time.Now().UnixNano())
 
 	nCPU := runtime.NumCPU()
+	// nCPU := 32
 	rngTests := make([]chan []int, nCPU)
 	for i := range rngTests {
 		c := make(chan []int)
@@ -46,8 +48,14 @@ func SimulateLootRNG() {
 	Returns 1 if the monster dropped an item and 0 otherwise
 	But if monster name doesn't contain any of character from `victory`, it will be treated as 0
 */
+
+var rx *regexp.Regexp
+var once sync.Once
+
 func interaction() int {
-	rx := regexp.MustCompile(`(?i)(.*)v(.*)|(.*)i(.*)|(.*)c(.*)|(.*)t(.*)|(.*)o(.*)|(.*)r(.*)|(.*)y(.*)`)
+	once.Do(func() {
+		rx = regexp.MustCompile(`(?i)(.*)v(.*)|(.*)i(.*)|(.*)c(.*)|(.*)t(.*)|(.*)o(.*)|(.*)r(.*)|(.*)y(.*)`)
+	})
 
 	monsterName := String(RandomNumber())
 	nameContainsVictory := rx.MatchString(monsterName)
@@ -103,5 +111,7 @@ func String(length int) string {
 func RandomNumber() int {
 	min := 10
 	max := 30
+
+	// return int(time.Now().UnixNano()%20 + 10)
 	return rand.Intn(max-min+1) + min
 }


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/andrepputra/benchmarking
BenchmarkGacha-16            139           9141413 ns/op
PASS
ok      github.com/andrepputra/benchmarking     2.140s

radityaqb@radityaqb-MS-7C82:~/go/src/github.com/andrepputra/benchmarking$ go test -bench=Gacha
goos: linux
goarch: amd64
pkg: github.com/andrepputra/benchmarking
BenchmarkGacha-16            372           3212452 ns/op
PASS
ok      github.com/andrepputra/benchmarking     1.523s

radityaqb@radityaqb-MS-7C82:~/go/src/github.com/andrepputra/benchmarking$ go test -bench=Gacha
goos: linux
goarch: amd64
pkg: github.com/andrepputra/benchmarking
BenchmarkGacha-16          60462             19122 ns/op
PASS
ok      github.com/andrepputra/benchmarking     1.360s

```