### PR TITLE
Rizki Benchmarking

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSimulateLootRNG(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		SimulateLootRNG()
+	}
+}


### PR DESCRIPTION
Before:
BenchmarkSimulateLootRNG-4                32          42091890 ns/op
PASS
ok      github.com/therizk/benchmarking 3.189s

After:
pkg: github.com/therizk/benchmarking
BenchmarkSimulateLootRNG-4           334           3359313 ns/op
PASS
ok      github.com/therizk/benchmarking 1.490s