### PR TITLE
performance benchmarking

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func SimulateLootRNG() {
 	rand.Seed(time.Now().UnixNano())
 
 	nCPU := runtime.NumCPU()
-	rngTests := make([]chan []int, nCPU)
+	rngTests := make([]chan []int, 0, nCPU)
 	for i := range rngTests {
 		c := make(chan []int)
 		//divide per CPU thread
@@ -68,7 +68,7 @@ func interaction() int {
  * Runs several interactions and retuns a slice representing the results
  */
 func simulation(n int) []int {
-	interactions := make([]int, n)
+	interactions := make([]int, 0, n)
 	for i := range interactions {
 		interactions[i] = interaction()
 	}
@@ -79,7 +79,7 @@ func simulation(n int) []int {
  * Runs several simulations and returns the results
  */
 func simulateRNG(n int, c chan []int) {
-	simulations := make([]int, n)
+	simulations := make([]int, 0, n)
 	for i := range simulations {
 		for _, v := range simulation(numberOfInteraction) {
 			simulations[i] += v
@@ -89,7 +89,7 @@ func simulateRNG(n int, c chan []int) {
 }
 
 func StringWithCharset(length int, charset string) string {
-	b := make([]byte, length)
+	b := make([]byte, 0, length)
 	for i := range b {
 		b[i] = charset[rand.Intn(len(charset))]
 	}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	crypto_rand "crypto/rand"
+	"encoding/binary"
 	"math/rand"
 	"regexp"
 	"runtime"
-	"time"
 )
 
 const (
@@ -19,15 +20,20 @@ func main() {
 }
 
 func SimulateLootRNG() {
-	rand.Seed(time.Now().UnixNano())
+	var b [8]byte
+	_, err := crypto_rand.Read(b[:])
+	if err != nil {
+		panic("cannot seed math/rand package with cryptographically secure random number generator")
+	}
+	rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
 
 	nCPU := runtime.NumCPU()
 	rngTests := make([]chan []int, 0, nCPU)
-	for i := range rngTests {
+	for i := 0; i < nCPU; i++ {
 		c := make(chan []int)
 		//divide per CPU thread
 		go simulateRNG(numberOfSimulation/nCPU, c)
-		rngTests[i] = c
+		rngTests = append(rngTests, c)
 	}
 
 	// Concatentate the test results
@@ -69,8 +75,8 @@ func interaction() int {
  */
 func simulation(n int) []int {
 	interactions := make([]int, 0, n)
-	for i := range interactions {
-		interactions[i] = interaction()
+	for i := 0; i < n; i++ {
+		interactions = append(interactions, interaction())
 	}
 	return interactions
 }
@@ -79,10 +85,10 @@ func simulation(n int) []int {
  * Runs several simulations and returns the results
  */
 func simulateRNG(n int, c chan []int) {
-	simulations := make([]int, 0, n)
-	for i := range simulations {
+	simulations := make([]int, n)
+	for i := 0; i < n; i++ {
 		for _, v := range simulation(numberOfInteraction) {
-			simulations[i] += v
+			simulations = append(simulations, simulations[i]+v)
 		}
 	}
 	c <- simulations
@@ -90,8 +96,8 @@ func simulateRNG(n int, c chan []int) {
 
 func StringWithCharset(length int, charset string) string {
 	b := make([]byte, 0, length)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
+	for i := 0; i < length; i++ {
+		b = append(b, charset[rand.Intn(len(charset))])
 	}
 	return string(b)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+)
+
+func BenchmarkSimulateLootRNG(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		SimulateLootRNG()
+	}
+}


### PR DESCRIPTION
Running `go test -run=. -bench=. -benchmem -benchtime=1s`
**Before**
```
goos: darwin
goarch: amd64
BenchmarkSimulateLootRNG-8           100          11283430 ns/op        30158230 B/op     150532 allocs/op
PASS
ok      _/Users/zahrah.afifah/Documents/workshop/benchmarking   1.480s
```
**After**
```
goos: darwin
goarch: amd64
BenchmarkSimulateLootRNG-8           105          10945871 ns/op        30187422 B/op     150587 allocs/op
PASS
ok      _/Users/zahrah.afifah/Documents/workshop/benchmarking   2.194s
```