### PR TITLE
gobench test

### DIFF
--- a/coret.text
+++ b/coret.text
@@ -1,0 +1,5 @@
+Before:
+BenchmarkSimulateLootRNG-4           109          19571826 ns/op        29589111 B/op     150459 allocs/op
+
+After:
+BenchmarkSimulateLootRNG-4           109           3172909 ns/op          102071 B/op       3225 allocs/op

--- a/main.go
+++ b/main.go
@@ -14,6 +14,12 @@ const (
 	charset             = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
 
+var (
+	minRand = 10
+	maxRand = 30
+	rx      = regexp.MustCompile(`(?i)(.*)v(.*)|(.*)i(.*)|(.*)c(.*)|(.*)t(.*)|(.*)o(.*)|(.*)r(.*)|(.*)y(.*)`)
+)
+
 func main() {
 	SimulateLootRNG()
 }
@@ -47,17 +53,11 @@ func SimulateLootRNG() {
 	But if monster name doesn't contain any of character from `victory`, it will be treated as 0
 */
 func interaction() int {
-	rx := regexp.MustCompile(`(?i)(.*)v(.*)|(.*)i(.*)|(.*)c(.*)|(.*)t(.*)|(.*)o(.*)|(.*)r(.*)|(.*)y(.*)`)
-
-	monsterName := String(RandomNumber())
-	nameContainsVictory := rx.MatchString(monsterName)
-	isItemDrop := rand.Float64() <= dropRate
-
-	if !nameContainsVictory {
+	if !rx.MatchString(String(RandomNumber())) {
 		return 0
 	}
 
-	if isItemDrop {
+	if rand.Float64() <= dropRate {
 		return 1
 	}
 
@@ -101,7 +101,5 @@ func String(length int) string {
 }
 
 func RandomNumber() int {
-	min := 10
-	max := 30
-	return rand.Intn(max-min+1) + min
+	return rand.Intn(maxRand-minRand+1) + minRand
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSimulateLootRNG(bench *testing.B) {
+	for n := 0; n < bench.N; n++ {
+		SimulateLootRNG()
+	}
+}

--- a/makefile
+++ b/makefile
@@ -1,0 +1,9 @@
+gobench:
+	@go test -bench=. -benchtime=109x
+
+gobench_mem:
+	@go test -bench=. -benchtime=109x -benchmem 
+
+gobench_cpuout:
+	@go test -bench=. -benchtime=109x -cpuprofile=cpu.out
+	@go tool pprof --pdf benchmarking.test cpu.out > cpu0.pdf


### PR DESCRIPTION
Before:
BenchmarkSimulateLootRNG-4           109          19571826 ns/op        29589111 B/op     150459 allocs/op

After:
BenchmarkSimulateLootRNG-4           109           3172909 ns/op          102071 B/op       3225 allocs/op