### PR TITLE
benchmarking

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,10 @@ const (
 	charset             = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
 
+var (
+	rx = regexp.MustCompile(`(?i)(.*)v(.*)|(.*)i(.*)|(.*)c(.*)|(.*)t(.*)|(.*)o(.*)|(.*)r(.*)|(.*)y(.*)`)
+)
+
 func main() {
 	SimulateLootRNG()
 }
@@ -47,17 +51,11 @@ func SimulateLootRNG() {
 	But if monster name doesn't contain any of character from `victory`, it will be treated as 0
 */
 func interaction() int {
-	rx := regexp.MustCompile(`(?i)(.*)v(.*)|(.*)i(.*)|(.*)c(.*)|(.*)t(.*)|(.*)o(.*)|(.*)r(.*)|(.*)y(.*)`)
-
-	monsterName := String(RandomNumber())
-	nameContainsVictory := rx.MatchString(monsterName)
-	isItemDrop := rand.Float64() <= dropRate
-
-	if !nameContainsVictory {
+	if !rx.MatchString(String(RandomNumber())) {
 		return 0
 	}
 
-	if isItemDrop {
+	if rand.Float64() <= dropRate {
 		return 1
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSimulateLootRNG(bench *testing.B) {
+	for n := 0; n < bench.N; n++ {
+		SimulateLootRNG()
+	}
+}


### PR DESCRIPTION
go test -run=XXX -bench=. -benchmem -benchtime=1s

Before
BenchmarkSimulateLootRNG-8           109          11935521 ns/op        30215156 B/op     150532 allocs/op

After
BenchmarkSimulateLootRNG-8           349           3347595 ns/op          104184 B/op       3233 allocs/op